### PR TITLE
Add scikit-image dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you find Faster R-CNN useful in your research, please consider citing:
   ```
 
   You can download my [Makefile.config](http://www.cs.berkeley.edu/~rbg/fast-rcnn-data/Makefile.config) for reference.
-2. Python packages you might not have: `cython`, `python-opencv`, `easydict`
+2. Python packages you might not have: `cython`, `python-opencv`, `easydict`, `scikit-image`
 3. [Optional] MATLAB is required for **official** PASCAL VOC evaluation only. The code now includes unofficial Python evaluation code.
 
 ### Requirements: hardware


### PR DESCRIPTION
scikit-image is used, otherwise you get:

``"No module named skimage.io"``
To fix this on Ubuntu 16.04 I ran:
``pip install -U scikit-image``