### PR TITLE
Add dropout layers to COCO models

### DIFF
--- a/models/coco/VGG16/fast_rcnn/test.prototxt
+++ b/models/coco/VGG16/fast_rcnn/test.prototxt
@@ -419,6 +419,15 @@ layer {
   top: "fc6"
 }
 layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
   name: "fc7"
   type: "InnerProduct"
   bottom: "fc6"
@@ -440,6 +449,15 @@ layer {
   type: "ReLU"
   bottom: "fc7"
   top: "fc7"
+}
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
 }
 layer {
   name: "cls_score"

--- a/models/coco/VGG16/fast_rcnn/train.prototxt
+++ b/models/coco/VGG16/fast_rcnn/train.prototxt
@@ -399,6 +399,15 @@ layer {
   top: "fc6"
 }
 layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
   name: "fc7"
   type: "InnerProduct"
   bottom: "fc6"
@@ -418,6 +427,15 @@ layer {
   type: "ReLU"
   bottom: "fc7"
   top: "fc7"
+}
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
 }
 layer {
   name: "cls_score"

--- a/models/coco/VGG16/faster_rcnn_end2end/test.prototxt
+++ b/models/coco/VGG16/faster_rcnn_end2end/test.prototxt
@@ -510,6 +510,15 @@ layer {
   top: "fc6"
 }
 layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
   name: "fc7"
   type: "InnerProduct"
   bottom: "fc6"
@@ -531,6 +540,15 @@ layer {
   type: "ReLU"
   bottom: "fc7"
   top: "fc7"
+}
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
 }
 layer {
   name: "cls_score"

--- a/models/coco/VGG16/faster_rcnn_end2end/train.prototxt
+++ b/models/coco/VGG16/faster_rcnn_end2end/train.prototxt
@@ -554,6 +554,15 @@ layer {
   top: "fc6"
 }
 layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
   name: "fc7"
   type: "InnerProduct"
   bottom: "fc6"
@@ -573,6 +582,15 @@ layer {
   type: "ReLU"
   bottom: "fc7"
   top: "fc7"
+}
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
 }
 layer {
   name: "cls_score"

--- a/models/coco/VGG_CNN_M_1024/fast_rcnn/test.prototxt
+++ b/models/coco/VGG_CNN_M_1024/fast_rcnn/test.prototxt
@@ -219,6 +219,15 @@ layer {
   top: "fc6"
 }
 layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
   name: "fc7"
   type: "InnerProduct"
   bottom: "fc6"
@@ -240,6 +249,15 @@ layer {
   type: "ReLU"
   bottom: "fc7"
   top: "fc7"
+}
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
 }
 layer {
   name: "cls_score"

--- a/models/coco/VGG_CNN_M_1024/fast_rcnn/train.prototxt
+++ b/models/coco/VGG_CNN_M_1024/fast_rcnn/train.prototxt
@@ -206,6 +206,15 @@ layer {
   top: "fc6"
 }
 layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
   name: "fc7"
   type: "InnerProduct"
   bottom: "fc6"
@@ -225,6 +234,15 @@ layer {
   type: "ReLU"
   bottom: "fc7"
   top: "fc7"
+}
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
 }
 layer {
   name: "cls_score"

--- a/models/coco/VGG_CNN_M_1024/faster_rcnn_end2end/test.prototxt
+++ b/models/coco/VGG_CNN_M_1024/faster_rcnn_end2end/test.prototxt
@@ -352,6 +352,15 @@ layer {
   top: "fc6"
 }
 layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
   name: "fc7"
   type: "InnerProduct"
   bottom: "fc6"
@@ -373,6 +382,15 @@ layer {
   type: "ReLU"
   bottom: "fc7"
   top: "fc7"
+}
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
 }
 layer {
   name: "cls_score"

--- a/models/coco/VGG_CNN_M_1024/faster_rcnn_end2end/train.prototxt
+++ b/models/coco/VGG_CNN_M_1024/faster_rcnn_end2end/train.prototxt
@@ -365,6 +365,15 @@ layer {
   top: "fc6"
 }
 layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
   name: "fc7"
   type: "InnerProduct"
   bottom: "fc6"
@@ -384,6 +393,15 @@ layer {
   type: "ReLU"
   bottom: "fc7"
   top: "fc7"
+}
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
 }
 layer {
   name: "cls_score"


### PR DESCRIPTION
The 2 dropout layers of the bundled COCO models are missing. I've added them back for both the VGG16 and VGG_CNN_M_1024 models so they now correctly reflect the Pascal VOC models and the original VGG16 model as published.