### PR TITLE
Fix path in demo helper message

### DIFF
--- a/tools/demo.py
+++ b/tools/demo.py
@@ -123,7 +123,7 @@ if __name__ == '__main__':
                               NETS[args.demo_net][1])
 
     if not os.path.isfile(caffemodel):
-        raise IOError(('{:s} not found.\nDid you run ./data/script/'
+        raise IOError(('{:s} not found.\nDid you run ./data/scripts/'
                        'fetch_faster_rcnn_models.sh?').format(caffemodel))
 
     if args.cpu_mode:


### PR DESCRIPTION
The path to the `fetch_faster_rcnn_models.sh` script in the `demo.py` helper message is incorrect. This PR fixes the typo so that users who run the demo before downloading models will be able to copy the path to the script and run it.
