### PR TITLE
Fix a small typo

### DIFF
--- a/lib/fast_rcnn/train.py
+++ b/lib/fast_rcnn/train.py
@@ -19,7 +19,7 @@ import google.protobuf as pb2
 
 class SolverWrapper(object):
     """A simple wrapper around Caffe's solver.
-    This wrapper gives us control over he snapshotting process, which we
+    This wrapper gives us control over the snapshotting process, which we
     use to unnormalize the learned bounding-box regression weights.
     """
 


### PR DESCRIPTION
Fix a small typo in a SolverWrapper class comment (`lib/fast_rcnn/train.py`).