### PR TITLE
GT boxes: exclude the ones that are iscrowd from COCO

### DIFF
--- a/lib/roi_data_layer/minibatch.py
+++ b/lib/roi_data_layer/minibatch.py
@@ -34,7 +34,8 @@ def get_minibatch(roidb, num_classes):
         assert len(im_scales) == 1, "Single batch only"
         assert len(roidb) == 1, "Single batch only"
         # gt boxes: (x1, y1, x2, y2, cls)
-        gt_inds = np.where(roidb[0]['gt_classes'] != 0)[0]
+        # For the GT boxes, exclude the ones that are ''iscrowd'' 
+        gt_inds = np.where(roidb[0]['gt_classes'] != 0 & np.all(roidb[0]['gt_overlaps'].toarray() > -1.0, axis=1))[0]
         gt_boxes = np.empty((len(gt_inds), 5), dtype=np.float32)
         gt_boxes[:, 0:4] = roidb[0]['boxes'][gt_inds, :] * im_scales[0]
         gt_boxes[:, 4] = roidb[0]['gt_classes'][gt_inds]


### PR DESCRIPTION
It seems like for the faster RCNN version of the code, the boxes that contain multiple objects ('iscrowd') are still included in the training. I am doing some side experiments to verify whether excluding them will improve performance. Creating this pull request.