### PR TITLE
fix `gt_boxes` shape in setup()

### DIFF
--- a/lib/roi_data_layer/layer.py
+++ b/lib/roi_data_layer/layer.py
@@ -102,7 +102,7 @@ class RoIDataLayer(caffe.Layer):
             self._name_to_top_map['im_info'] = idx
             idx += 1
 
-            top[idx].reshape(1, 4)
+            top[idx].reshape(1, 5)
             self._name_to_top_map['gt_boxes'] = idx
             idx += 1
         else: # not using RPN


### PR DESCRIPTION
Not affect during running time, just more logically consistent with the forward pass.

`gt_boxes`'s content is `(x1, y1, x2, y2, cls)`.