### PR TITLE
Update README With Workaroung for Recent CUDA/cuDNN

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ If you find Faster R-CNN useful in your research, please consider citing:
 
 ### Requirements: software
 
+**NOTE** If you are having issues compiling and you are using a recent version of CUDA/cuDNN, please consult [this issue](https://github.com/rbgirshick/py-faster-rcnn/issues/509?_pjax=%23js-repo-pjax-container#issuecomment-284133868) for a workaround
+
 1. Requirements for `Caffe` and `pycaffe` (see: [Caffe installation instructions](http://caffe.berkeleyvision.org/installation.html))
 
   **Note:** Caffe *must* be built with support for Python layers!


### PR DESCRIPTION
Code fails to build with recent CUDA/cuDNN, there is a suitable workaround in an issue. This commit adds a link to the issue from the top-level readme