### PR TITLE
Adding info for docker image for cpu running demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ If you find Faster R-CNN useful in your research, please consider citing:
 
 ### Installation (sufficient for the demo)
 
+**Note:** If you don't have GPU, you can run the demo just using your CPU and [this](https://hub.docker.com/r/danielariesgo/py-faster-rcnn/) Docker image.
+In this case, you should only [install Docker](https://docs.docker.com/engine/installation/) and follow the instructions in the docker image's readme.
+
+
 1. Clone the Faster R-CNN repository
   ```Shell
   # Make sure to clone with --recursive


### PR DESCRIPTION
There are so many issues with running the CPU mode (#272, #564 and so on). I suffered the same problems, so I decided to do a docker image for it.

It's not so nice because I had to change files and code to make it work (you can see it in the Dockerfile) it would be great if you consider having a branch with those changes or something, because if the code is changed from now on, the image may not work anymore.

Nonetheless, it was great to finally see it working and I hope more people benefit from it.